### PR TITLE
Clarify facet value retrieval in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,7 @@ client.setNumberOfFacets(20);
 ```
 
 Note: if a field has more values than the defined limit, the returned values are the first N in
-alphabetical order, not the N with most hits. Increase the limit if you need to make sure that all
-values are included.
+alphabetical order, not the N with most hits. Increase the limit if you need more values.
 
 #### Numerical range facets
 

--- a/README.md
+++ b/README.md
@@ -283,12 +283,16 @@ client.addFacetField('category');
 client.addFacetField('custom_fields.genre');
 ```
 
-By default, 10 facets with most hits are returned per field. Use the following function to get more
-or less facets.
+Facet values are returned in alphabetical order, 10 values per field by default. Use the following
+function to get more or less facets.
 
 ```js
 client.setNumberOfFacets(20);
 ```
+
+Note: if a field has more values than the defined limit, the returned values are the first N in
+alphabetical order, not the N with most hits. Increase the limit if you need to make sure that all
+values are included.
 
 #### Numerical range facets
 


### PR DESCRIPTION
Updated documentation to clarify facet value retrieval and sorting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified default facet ordering and selection behavior (alphabetical order, 10 values per field).
  * Added guidance on changing the facet limit via `setNumberOfFacets`.
  * Noted that when a field has more values than the limit, the first N alphabetically are returned (not by hit count).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->